### PR TITLE
Beam API updates

### DIFF
--- a/Modules/Livestream.cs
+++ b/Modules/Livestream.cs
@@ -95,9 +95,9 @@ namespace Botwinder.Modules
 			public const string HitboxTitle = "media_status";
 			public const string HitboxUrl = "media_name"; //"channel_link"; -> that doesn't work...
 
-			public const string BeamBaseUrl = "https://beam.pro/api/v1/channels/";
+			public const string BeamBaseUrl = "https://beam.pro/api/v1/resources/";
 			public const string BeamIsLive = "online"; //bool
-			public const string BeamDisplayName = "token";
+			public const string BeamDisplayName = "token"; //this may be "channelIdOrToken"
 			public const string BeamGameParent = "type"; //object
 			public const string BeamGame = "name";
 			public const string BeamTitle = "name";


### PR DESCRIPTION
Microsoft changed the URL at which the API was accessed. Have linked up
to the new REST API link and provided a new way to access the channel ID
in an in-line comment if it was also modified.