### PR TITLE
Formatting of Code Verification PM

### DIFF
--- a/Bot/ModCommands.cs
+++ b/Bot/ModCommands.cs
@@ -604,7 +604,6 @@ namespace Botwinder.Bot
 				try
 				{
 					List<User> mutedUsers = new List<User>();
-				    List<User> idMutedUsers = Utils.GetMentionedUsers(e);
 					lock(client.ServersLock)
 					{
 						foreach(User user in e.Message.MentionedUsers)
@@ -623,22 +622,6 @@ namespace Botwinder.Bot
 
 							mutedUsers.Add(user);
 						}
-					    foreach(User user in idMutedUsers)
-					    {
-					        if( e.Server.IsAdmin(user) || e.Server.IsModerator(user) || (e.Server.ServerConfig.MutedUsers != null && e.Server.ServerConfig.MutedUsers.Contains(user.Id)) )
-					            continue;
-
-					        if( e.Server.ServerConfig.MutedUsers == null )
-					            e.Server.ServerConfig.MutedUsers = new guid[1];
-					        else
-					            Array.Resize<guid>(ref e.Server.ServerConfig.MutedUsers, e.Server.ServerConfig.MutedUsers.Length + 1);
-
-					        e.Server.ServerConfig.MutedUsers[e.Server.ServerConfig.MutedUsers.Length - 1] = user.Id;
-					        e.Server.ServerConfig.MuteDuration = (e.Server.ServerConfig.MuteDuration < 5 ? 5 : e.Server.ServerConfig.MuteDuration > 60 ? 60 : e.Server.ServerConfig.MuteDuration);
-					        e.Server.ServerConfig.SaveAsync();
-
-					        mutedUsers.Add(user);
-					    }
 					}
 
 					foreach(User user in mutedUsers)

--- a/Bot/ModCommands.cs
+++ b/Bot/ModCommands.cs
@@ -604,6 +604,7 @@ namespace Botwinder.Bot
 				try
 				{
 					List<User> mutedUsers = new List<User>();
+				    List<User> idMutedUsers = Utils.GetMentionedUsers(e);
 					lock(client.ServersLock)
 					{
 						foreach(User user in e.Message.MentionedUsers)
@@ -622,6 +623,22 @@ namespace Botwinder.Bot
 
 							mutedUsers.Add(user);
 						}
+					    foreach(User user in idMutedUsers)
+					    {
+					        if( e.Server.IsAdmin(user) || e.Server.IsModerator(user) || (e.Server.ServerConfig.MutedUsers != null && e.Server.ServerConfig.MutedUsers.Contains(user.Id)) )
+					            continue;
+
+					        if( e.Server.ServerConfig.MutedUsers == null )
+					            e.Server.ServerConfig.MutedUsers = new guid[1];
+					        else
+					            Array.Resize<guid>(ref e.Server.ServerConfig.MutedUsers, e.Server.ServerConfig.MutedUsers.Length + 1);
+
+					        e.Server.ServerConfig.MutedUsers[e.Server.ServerConfig.MutedUsers.Length - 1] = user.Id;
+					        e.Server.ServerConfig.MuteDuration = (e.Server.ServerConfig.MuteDuration < 5 ? 5 : e.Server.ServerConfig.MuteDuration > 60 ? 60 : e.Server.ServerConfig.MuteDuration);
+					        e.Server.ServerConfig.SaveAsync();
+
+					        mutedUsers.Add(user);
+					    }
 					}
 
 					foreach(User user in mutedUsers)

--- a/Modules/Verification.cs
+++ b/Modules/Verification.cs
@@ -413,7 +413,7 @@ namespace Botwinder.Modules
 				if( !this.HashedValues.ContainsKey(hash) )
 					this.HashedValues.Add(hash, new HashedValue(user.Id, server.ID));
 
-				verifyPm = "In order to get verified, you must reply to me with a hidden code within the below rules. " +
+				verifyPm = "In order to get verified, you must reply to me with a hidden code **within the below rules.** " +
 				           "Just the code by itself, do not add anything extra. Read the rules and you will find the code.\n" +
 				           "_(Beware that this will expire in a few hours, " +
 				           "if it does simply run the `verify` command in the server chat, " +
@@ -432,7 +432,7 @@ namespace Botwinder.Modules
 					if( (words = lines[i].Split(' ')).Length > 10 )
 					{
 						int space = Utils.Random.Next(words.Length / 4, words.Length - 1);
-						lines[i] = lines[i].Insert(lines[i].IndexOf(words[space]) - 1, " the secret is: " + hash );
+						lines[i] = lines[i].Insert(lines[i].IndexOf(words[space]) - 1, " (the secret is: " + hash + ")" );
 
 						hashBuilder = new StringBuilder(lines.Length+1);
 						hashBuilder.AppendLine(verifyPm).AppendLine("");


### PR DESCRIPTION
Some users have asked where the code is, so saying "The code is in the message" has been bolded.

Additionally some users have responded with the wrong code because they thought the next word was part of the code, so the secret is now surrounded by parentheses, which is less obtrusive then italics or bold, but improves clarity somewhat.